### PR TITLE
Apply Liquid Glass styling to procon34 page

### DIFF
--- a/procon34/index.html
+++ b/procon34/index.html
@@ -1,36 +1,107 @@
 <!DOCTYPE html>
-<html>
-	<head>
-	    <meta charset="utf-8" />
-		<link rel="icon" type="image/x-icon" href="favicon.ico"/>
-		<link rel="stylesheet" href="./style.css">
-		<title>Learn Mate(procon34)</title>
-	</head>
-	<body>
-		<h1>Learn Mate</h1>
-		<phrase>
-			学習を、次のステージへ。
-		</phrase>
-		<cap>
-		<br />
-		今まで単調だった学習を楽しみへ。その信念のもと私たち有明高専は今あるシステムをより使いやすく、より気軽に質問ができる学習支援システム｢Learn Mate｣を提案します。
-		</cap>
-		<h3>｢わからない｣は<br />｢わかりたい｣へ。</h3>
-		<div class="box"><figure class="side"><img src="screen2.jpg"></figure>
-			<p class="side_text">学習におけるなによりの特徴、それは分かった時に得られる自信と喜びです。反対に、わからないことを放置していると不安や後ろめたさが出てきます。Learn Mateはそんな｢わからない｣を抱える学生にとって最も心強い味方です。質問をクラスメイトに、そして先生に送りましょう。匿名になっているため心配はいりません。</p>
-		</div>
-		<h3><br>外部ツールとのやりとりも一瞬。</h3>
-		<div class="box">
-			<figure class="side"><img src="screen1.jpg"></figure>
-			<p class="side_text">他のツールに使い慣れていて、どうしても外部サービスを使いたい先生にも寄り添います。アプリ内に外部リンクを埋め込むことでLearn Mate内から外部サービスにアクセスできます。もう、いくつものサービスを行き来するために複数のアプリを開いたり、ブラウザで複数のタブを開いたりする必要はありません。</p>
-		</div>
-		<h3><br>｢やりたい｣も｢やらなきゃ｣も<br />これ一つで。</h3>
-		<div class="box">
-			<figure class="side"><img src="screen4.jpg"></figure>
-			<p class="side_text">学習は最適な計画を組んでこそ、より効果のあるものとなります。Learn Mateを使って課題や、自主学習の計画を管理して残った時間をあなただけの素敵な時間にしましょう。</p></div>
-		<h3><br>適切なプロファイル。<br />確実に必要な情報をあなたに。</h3>
-		<div class="box">
-			<figure class="side"><img src="screen3.jpg"></figure>
-			<p class="side_text">学生は普段部活、学年、クラスなどの様々な場において力を発揮しています。そんな学校生活をLearn Mateは全力で後押しするために、LMパーソナルを提供します。これを使えば、他のクラスや部活との交流をシームレスにするでしょう。</p></div>
-	</body>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" type="image/x-icon" href="favicon.ico" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="./style.css" />
+    <title>Learn Mate(procon34)</title>
+  </head>
+  <body>
+    <header class="project-header">
+      <div class="project-header__brand">
+        <h1 class="project-header__title">Learn Mate</h1>
+        <p class="project-header__tagline">学習を、次のステージへ。</p>
+      </div>
+    </header>
+
+    <main class="project-main">
+      <section class="project-panel" aria-labelledby="overview-title">
+        <div class="project-panel__inner">
+          <h2 id="overview-title" class="project-panel__title">概要</h2>
+          <p class="project-panel__lead">
+            今まで単調だった学習を楽しみへ。その信念のもと私たち有明高専は今あるシステムをより使いやすく、より気軽に質問ができる学習支援システム｢Learn Mate｣を提案します。
+          </p>
+        </div>
+      </section>
+
+      <section class="feature" aria-labelledby="feature-questions">
+        <div class="feature__inner">
+          <h2 id="feature-questions" class="feature__title">
+            ｢わからない｣は｢わかりたい｣へ。
+          </h2>
+          <div class="feature__layout">
+            <figure class="feature__media">
+              <img src="screen2.jpg" alt="Learn Mateの質問画面" />
+            </figure>
+            <div class="feature__content">
+              <p>
+                学習におけるなによりの特徴、それは分かった時に得られる自信と喜びです。反対に、わからないことを放置していると不安や後ろめたさが出てきます。Learn Mateはそんな｢わからない｣を抱える学生にとって最も心強い味方です。質問をクラスメイトに、そして先生に送りましょう。匿名になっているため心配はいりません。
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="feature" aria-labelledby="feature-tools">
+        <div class="feature__inner">
+          <h2 id="feature-tools" class="feature__title">
+            外部ツールとのやりとりも一瞬。
+          </h2>
+          <div class="feature__layout">
+            <figure class="feature__media">
+              <img src="screen1.jpg" alt="外部リンク機能の画面" />
+            </figure>
+            <div class="feature__content">
+              <p>
+                他のツールに使い慣れていて、どうしても外部サービスを使いたい先生にも寄り添います。アプリ内に外部リンクを埋め込むことでLearn Mate内から外部サービスにアクセスできます。もう、いくつものサービスを行き来するために複数のアプリを開いたり、ブラウザで複数のタブを開いたりする必要はありません。
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="feature" aria-labelledby="feature-plan">
+        <div class="feature__inner">
+          <h2 id="feature-plan" class="feature__title">
+            ｢やりたい｣も｢やらなきゃ｣もこれ一つで。
+          </h2>
+          <div class="feature__layout">
+            <figure class="feature__media">
+              <img src="screen4.jpg" alt="学習計画機能の画面" />
+            </figure>
+            <div class="feature__content">
+              <p>
+                学習は最適な計画を組んでこそ、より効果のあるものとなります。Learn Mateを使って課題や、自主学習の計画を管理して残った時間をあなただけの素敵な時間にしましょう。
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="feature" aria-labelledby="feature-profile">
+        <div class="feature__inner">
+          <h2 id="feature-profile" class="feature__title">
+            適切なプロファイル。確実に必要な情報をあなたに。
+          </h2>
+          <div class="feature__layout">
+            <figure class="feature__media">
+              <img src="screen3.jpg" alt="LMパーソナルの画面" />
+            </figure>
+            <div class="feature__content">
+              <p>
+                学生は普段部活、学年、クラスなどの様々な場において力を発揮しています。そんな学校生活をLearn Mateは全力で後押しするために、LMパーソナルを提供します。これを使えば、他のクラスや部活との交流をシームレスにするでしょう。
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+  </body>
 </html>

--- a/procon34/style.css
+++ b/procon34/style.css
@@ -1,145 +1,170 @@
 :root {
-  color: #f6f6f6;
-  background-color: #2f2f2f;
-
-  font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
-  font-size: 16px;
-  line-height: 24px;
-  font-weight: 400;
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-text-size-adjust: 100%;
+  color-scheme: dark;
+  font-family: 'Noto Sans JP', 'Noto Sans', system-ui, -apple-system, BlinkMacSystemFont,
+    'Segoe UI', sans-serif;
+  --bg: radial-gradient(circle at 20% 20%, rgba(102, 161, 255, 0.18), transparent 55%),
+    radial-gradient(circle at 80% 15%, rgba(255, 176, 209, 0.18), transparent 60%),
+    #090c17;
+  --glass-surface: linear-gradient(135deg, rgba(255, 255, 255, 0.14), rgba(255, 255, 255, 0.02));
+  --glass-border: rgba(255, 255, 255, 0.18);
+  --text-primary: #f5f7ff;
+  --text-secondary: rgba(235, 238, 255, 0.72);
+  --accent: #7bd7ff;
+  --container: min(960px, 92vw);
+  --transition: 180ms ease;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: 0.75s;
+* {
+  box-sizing: border-box;
 }
 
-.logo.tauri:hover {
-  filter: drop-shadow(0 0 2em #24c8db);
-}
-
-.row {
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--bg);
+  color: var(--text-primary);
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+  gap: clamp(2rem, 6vw, 3.5rem);
+  padding: clamp(1.5rem, 5vw, 3rem) 0 4rem;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
+img {
+  max-width: 100%;
+  display: block;
+  border-radius: 18px;
 }
 
-a:hover {
-  color: #24c8db;
-}
-@media (max-width:768px) {
-	img {
-	  width:50%;
-	  height: auto;
-	}
-	img.icon {
-		width:90px;
-	}
-	figure.side {
-		display:inline-block;
-	}
-	h1 {
-	  text-align: center;
-	  color: #e0f82f;
-	}
-	.image {
-	  height: auto;
-	  margin-right: 10px;
-	}
-	phrase {
-		display: block;
-		text-align: center;
-		color: #ffffff;
-		font-size: 20px;
-	}
-	cap {
-	  text-align: center;
-	  color: #ffffff;
-	  font-size: 16px;
-	  display: block;
-	  letter-spacing:0.1em;
-	  line-height:1.1em;
-	}
-	body {
-	  padding: 2% 2%;
-	}
-	div.box {
-	  display: flex;
-	  width:100%;
-	  height:auto;
-	}
-	h3 {
-	  color: #96b6ff;
-	  font-size: 18px;
-	}
-	p.side_text {
-		display:inline-block;
-		width:95%;
-		vertical-align:bottom;
-		font-size:15px;
-	}
+.project-header {
+  width: var(--container);
+  background: var(--glass-surface);
+  border: 1px solid var(--glass-border);
+  border-radius: 22px;
+  padding: clamp(1.75rem, 4vw, 2.5rem);
+  box-shadow: 0 16px 30px rgba(6, 12, 24, 0.28);
+  backdrop-filter: blur(12px);
 }
 
-@media (min-width:769px) {
-	h1 {
-		text-align: center;
-		color: #e0f82f;
-		font-size: 4em;
-	}
-	img.icon {
-		width:120px;
-	}
-	figure.side {
-		display:inline-block;
-	}
-	phrase {
-		display: block;
-		text-align: center;
-		color: #ffffff;
-		font-size: 3em;
-		line-height:1.15em;
-	}
+.project-header__brand {
+  display: grid;
+  gap: 0.6rem;
+}
 
-	cap {
-		text-align: center;
-		color: #ffffff;
-		font-size: 2em;
-		line-height:1.15em;
-		letter-spacing:0.1em;
-		display: block;
-	}
-	body {
-		padding: 5% 5%;
-	}
-	h3 {
-		color: #96b6ff;
-		font-size: 2em;
-		letter-spacing:0.08em;
-		line-height:1.1em;
-	}
-	p{
-		width:95%;
-		font-size:1.5em;
-		letter-spacing: 0.08em;
-		line-height: 1.25em;
-		display:inline-block;
-		vertical-align:bottom;
-	}
-	div.box {
-	  display: flex;
-	  width:100%;
-	  height:auto;
-	  vertical-align:bottom;
-	}
+.project-header__title {
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 3rem);
+  letter-spacing: 0.08em;
+  font-weight: 600;
+}
+
+.project-header__tagline {
+  margin: 0;
+  font-size: clamp(1rem, 3vw, 1.35rem);
+  color: var(--text-secondary);
+  letter-spacing: 0.08em;
+}
+
+.project-main {
+  width: var(--container);
+  display: grid;
+  gap: clamp(2rem, 5vw, 3rem);
+}
+
+.project-panel,
+.feature {
+  background: var(--glass-surface);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 22px;
+  box-shadow: 0 16px 28px rgba(6, 12, 24, 0.24);
+  backdrop-filter: blur(12px);
+}
+
+.project-panel__inner,
+.feature__inner {
+  padding: clamp(1.75rem, 4vw, 2.75rem);
+  display: grid;
+  gap: clamp(1.25rem, 3vw, 1.8rem);
+}
+
+.project-panel__title,
+.feature__title {
+  margin: 0;
+  font-size: clamp(1.5rem, 3.5vw, 2rem);
+  font-weight: 600;
+  letter-spacing: 0.07em;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.project-panel__title::before,
+.feature__title::before {
+  content: '';
+  width: 32px;
+  height: 2px;
+  background: var(--accent);
+  border-radius: 999px;
+}
+
+.project-panel__lead {
+  margin: 0;
+  color: var(--text-secondary);
+  line-height: 1.8;
+  letter-spacing: 0.06em;
+}
+
+.feature__layout {
+  display: grid;
+  gap: clamp(1.5rem, 4vw, 2.25rem);
+}
+
+.feature__content p {
+  margin: 0;
+  color: var(--text-secondary);
+  line-height: 1.9;
+  letter-spacing: 0.05em;
+}
+
+.feature__media {
+  margin: 0;
+}
+
+.feature__media img {
+  width: 100%;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 12px 24px rgba(6, 12, 24, 0.35);
+}
+
+@media (min-width: 768px) {
+  .feature__layout {
+    grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
+    align-items: start;
+  }
+
+  .feature:nth-child(even) .feature__layout {
+    grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
+  }
+}
+
+@media (max-width: 767px) {
+  body {
+    padding-inline: 0;
+  }
+
+  .project-header,
+  .project-main > * {
+    border-radius: 18px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }


### PR DESCRIPTION
## Summary
- restyled `procon34/index.html` to reuse the portfolio's liquid glass layout while preserving existing copy and imagery
- refreshed the project-specific stylesheet to introduce glassmorphic panels with image/text layouts matching the top-level design language

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e3c78198ac8326adee10bbfab6e12f