### PR TITLE
Add activity media section to about panel

### DIFF
--- a/assets/css/portfolio.css
+++ b/assets/css/portfolio.css
@@ -152,6 +152,11 @@ body {
   gap: 0.6rem;
 }
 
+.about__media {
+  display: grid;
+  gap: 0.6rem;
+}
+
 .social-links {
   display: flex;
   flex-wrap: wrap;
@@ -191,6 +196,33 @@ body {
 
 .info-grid__value {
   font-weight: 500;
+}
+
+.media-links {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.media-links__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.5rem 1rem;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  text-decoration: none;
+  color: var(--text-secondary);
+  backdrop-filter: blur(6px);
+  transition: color var(--transition), border-color var(--transition);
+}
+
+.media-links__item:hover,
+.media-links__item:focus-visible {
+  color: var(--text-primary);
+  border-color: var(--accent);
 }
 
 .works {

--- a/index.html
+++ b/index.html
@@ -69,6 +69,21 @@
               >
             </div>
           </div>
+          <div class="about__media">
+            <span class="info-grid__label">Activity</span>
+            <ul class="media-links" aria-label="活動が紹介された記事や動画">
+              <li>
+                <a href="https://example.com/article" class="media-links__item"
+                  >活動が紹介された記事タイトル</a
+                >
+              </li>
+              <li>
+                <a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ" class="media-links__item"
+                  >活動紹介のYouTube動画</a
+                >
+              </li>
+            </ul>
+          </div>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- add a dedicated activity section on the About panel for highlighting media coverage
- introduce styling for media links to match the existing glassmorphism aesthetic

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e46326bc988326ab5d2a2391b7a1fc