### PR TITLE
Improve blog layout and split article routes

### DIFF
--- a/app/blog/_components/BlogPostArticle.tsx
+++ b/app/blog/_components/BlogPostArticle.tsx
@@ -1,0 +1,36 @@
+import Link from "next/link";
+import type { BlogPost } from "../posts";
+
+type BlogPostArticleProps = {
+  post: BlogPost;
+};
+
+export function BlogPostArticle({ post }: BlogPostArticleProps) {
+  return (
+    <main className="blog-post">
+      <Link className="blog-post__back" href="/blog">
+        ← 記事一覧に戻る
+      </Link>
+      <article>
+        <header className="blog-post__header">
+          <p className="blog-post__meta">
+            <time dateTime={post.date}>{post.date}</time>
+            <span aria-hidden="true">・</span>
+            <span>{post.readingTime}</span>
+          </p>
+          <h1>{post.title}</h1>
+          <ul className="blog-post__tags" aria-label="タグ">
+            {post.tags.map((tag) => (
+              <li key={tag}>#{tag}</li>
+            ))}
+          </ul>
+        </header>
+        <div className="blog-post__body">
+          {post.body.map((paragraph, index) => (
+            <p key={index}>{paragraph}</p>
+          ))}
+        </div>
+      </article>
+    </main>
+  );
+}

--- a/app/blog/layout.tsx
+++ b/app/blog/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from "react";
+
+export default function BlogLayout({
+  children
+}: {
+  children: ReactNode;
+}) {
+  return <div className="blog-page-wrapper">{children}</div>;
+}

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,0 +1,48 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { posts } from "./posts";
+
+export const metadata: Metadata = {
+  title: "Blog",
+  description: "最新の活動や学びをまとめたブログ記事の一覧です。"
+};
+
+export default function BlogIndexPage() {
+  return (
+    <main className="blog-container">
+      <header className="blog-header">
+        <h1>Blog</h1>
+        <p>最近取り組んだプロジェクトや学びのメモをまとめています。</p>
+      </header>
+      <ul className="blog-list">
+        {posts.map((post) => (
+          <li key={post.slug} className="blog-card">
+            <article>
+              <header>
+                <p className="blog-card__meta">
+                  <time dateTime={post.date}>{post.date}</time>
+                  <span aria-hidden="true">・</span>
+                  <span>{post.readingTime}</span>
+                </p>
+                <h2 className="blog-card__title">
+                  <Link href={`/blog/${post.slug}`}>{post.title}</Link>
+                </h2>
+              </header>
+              <p className="blog-card__description">{post.description}</p>
+              <ul className="blog-card__tags" aria-label="タグ">
+                {post.tags.map((tag) => (
+                  <li key={tag}>#{tag}</li>
+                ))}
+              </ul>
+              <footer>
+                <Link className="blog-card__link" href={`/blog/${post.slug}`}>
+                  記事を読む
+                </Link>
+              </footer>
+            </article>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/app/blog/portfolio-refresh-2024/page.tsx
+++ b/app/blog/portfolio-refresh-2024/page.tsx
@@ -1,0 +1,32 @@
+import type { Metadata } from "next";
+import { BlogPostArticle } from "../_components/BlogPostArticle";
+import { getPostBySlug } from "../posts";
+
+const slug = "portfolio-refresh-2024";
+
+function resolvePost() {
+  const postBySlug = getPostBySlug(slug);
+
+  if (!postBySlug) {
+    throw new Error(`Blog post with slug "${slug}" was not found.`);
+  }
+
+  return postBySlug;
+}
+
+const post = resolvePost();
+
+export const metadata: Metadata = {
+  title: post.title,
+  description: post.description,
+  openGraph: {
+    title: post.title,
+    description: post.description,
+    type: "article",
+    publishedTime: post.date
+  }
+};
+
+export default function PortfolioRefresh2024Page() {
+  return <BlogPostArticle post={post} />;
+}

--- a/app/blog/posts.ts
+++ b/app/blog/posts.ts
@@ -1,0 +1,58 @@
+export type BlogPost = {
+  slug: string;
+  title: string;
+  description: string;
+  date: string;
+  readingTime: string;
+  tags: string[];
+  body: string[];
+};
+
+export const posts: BlogPost[] = [
+  {
+    slug: "portfolio-refresh-2024",
+    title: "2024年ポートフォリオ刷新の舞台裏",
+    description:
+      "デザインコンセプトを磨き込みながら、App Routerへの移行とアクセシビリティ改善に取り組んだ記録です。",
+    date: "2024-06-20",
+    readingTime: "4 min read",
+    tags: ["Design", "Next.js", "Accessibility"],
+    body: [
+      "今年のポートフォリオでは、静的なページ群からApp Routerを使った構造へ移行しました。ヘッダーやコンポーネントを分解し、ルーティングを明確化することで、コンテンツ追加のスピードが劇的に向上しました。",
+      "特に意識したのは視認性とキーボード操作のしやすさです。ナビゲーションのラベルを改善し、ARIA属性を活用したことで、読み上げソフトでも迷わず移動できるようになりました。",
+      "この刷新を通じて、デザイナーとエンジニアの観点を往復するプロセスの大切さを再確認しました。細部までこだわることで、体験のクオリティは確実に向上します。"
+    ]
+  },
+  {
+    slug: "rust-backend-memo",
+    title: "Rustバックエンド開発のメモ",
+    description:
+      "Actix-Webでの開発フローを整理しながら、Rustらしいエラーハンドリングや型設計について振り返りました。",
+    date: "2024-05-02",
+    readingTime: "6 min read",
+    tags: ["Rust", "Backend", "Actix"],
+    body: [
+      "RustでAPIサーバーを実装すると、型安全なハンドラーと落ち着いたパフォーマンスが得られます。特にActix-Webのextractorは便利で、リクエスト検証のコード量をかなり削減できます。",
+      "一方で、エラーハンドリングの分岐が増えると読みづらさが出てきます。Result型をうまく活用し、contextを加えながらanyhowでまとめる手法が現場でも好評でした。",
+      "今回のプロジェクトでは、OpenAPIドキュメントの自動生成も導入しました。テストとドキュメントの同期が取りやすくなり、フロントとの調整がスムーズになった点が大きな収穫です。"
+    ]
+  },
+  {
+    slug: "study-note-growth-mindset",
+    title: "学び続けるためのマインドセット",
+    description:
+      "技術的な挑戦を継続するために意識している、日々の習慣や学習サイクルの作り方を紹介します。",
+    date: "2024-03-18",
+    readingTime: "3 min read",
+    tags: ["Learning", "Mindset"],
+    body: [
+      "技術領域は日々アップデートされるため、キャッチアップのリズムを作ることが欠かせません。私は毎朝30分のインプットタイムを確保し、論文やRFCを読むようにしています。",
+      "インプットだけで終わらせず、必ず小さなアウトプットにつなげるのがコツです。週末には学んだ内容をまとめ、翌週のタスクに反映させています。",
+      "また、学習ログをNotionで管理し、振り返りのサイクルを回すことで、モチベーションを維持しています。継続の鍵は、自分に合ったリズムを早く見つけることに尽きます。"
+    ]
+  }
+];
+
+export function getPostBySlug(slug: string) {
+  return posts.find((post) => post.slug === slug);
+}

--- a/app/blog/rust-backend-memo/page.tsx
+++ b/app/blog/rust-backend-memo/page.tsx
@@ -1,0 +1,31 @@
+import type { Metadata } from "next";
+import { BlogPostArticle } from "../_components/BlogPostArticle";
+import { getPostBySlug } from "../posts";
+
+const slug = "rust-backend-memo";
+function resolvePost() {
+  const postBySlug = getPostBySlug(slug);
+
+  if (!postBySlug) {
+    throw new Error(`Blog post with slug "${slug}" was not found.`);
+  }
+
+  return postBySlug;
+}
+
+const post = resolvePost();
+
+export const metadata: Metadata = {
+  title: post.title,
+  description: post.description,
+  openGraph: {
+    title: post.title,
+    description: post.description,
+    type: "article",
+    publishedTime: post.date
+  }
+};
+
+export default function RustBackendMemoPage() {
+  return <BlogPostArticle post={post} />;
+}

--- a/app/blog/study-note-growth-mindset/page.tsx
+++ b/app/blog/study-note-growth-mindset/page.tsx
@@ -1,0 +1,31 @@
+import type { Metadata } from "next";
+import { BlogPostArticle } from "../_components/BlogPostArticle";
+import { getPostBySlug } from "../posts";
+
+const slug = "study-note-growth-mindset";
+function resolvePost() {
+  const postBySlug = getPostBySlug(slug);
+
+  if (!postBySlug) {
+    throw new Error(`Blog post with slug "${slug}" was not found.`);
+  }
+
+  return postBySlug;
+}
+
+const post = resolvePost();
+
+export const metadata: Metadata = {
+  title: post.title,
+  description: post.description,
+  openGraph: {
+    title: post.title,
+    description: post.description,
+    type: "article",
+    publishedTime: post.date
+  }
+};
+
+export default function StudyNoteGrowthMindsetPage() {
+  return <BlogPostArticle post={post} />;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,16 +1,150 @@
-@import url("/assets/css/portfolio.css");
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
 :root {
   color-scheme: light;
 }
 
-*,
-*::before,
-*::after {
-  box-sizing: border-box;
+body {
+  background-color: #f4f6fb;
+  color: #1f2933;
+  -webkit-font-smoothing: antialiased;
+  margin: 0;
 }
 
-body {
-  margin: 0;
+.blog-page-wrapper {
+  min-height: 100vh;
+  padding: 0 2.5rem;
+  background: radial-gradient(circle at top, #1f2a45 0%, #0f172a 55%, #050b16 100%);
+}
+
+main.blog-container,
+main.blog-post {
+  color: #e2e8f0;
+  font-family: "Noto Sans JP", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  padding: 7rem 1.5rem 4rem;
+  max-width: 960px;
+  margin: 0 auto;
+  line-height: 1.8;
   background-color: #0f172a;
+}
+
+.blog-header {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.blog-header h1 {
+  font-size: clamp(2rem, 4vw, 3rem);
+  margin-bottom: 0.75rem;
+}
+
+.blog-header p {
+  color: #cbd5f5;
+  margin: 0;
+}
+
+.blog-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1.75rem;
+}
+
+.blog-card {
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 1.25rem;
+  padding: 1.75rem;
+  backdrop-filter: blur(16px);
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.blog-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(129, 140, 248, 0.7);
+}
+
+.blog-card__meta,
+.blog-post__meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  color: #94a3b8;
+  margin-bottom: 0.75rem;
+}
+
+.blog-card__title {
+  font-size: clamp(1.25rem, 2.4vw, 1.75rem);
+  margin: 0;
+}
+
+.blog-card__title a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.blog-card__title a:hover,
+.blog-card__link:hover,
+.blog-post__back:hover {
+  color: #a5b4fc;
+}
+
+.blog-card__description {
+  margin: 0.75rem 0 1rem;
+  color: #cbd5f5;
+}
+
+.blog-card__tags,
+.blog-post__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+  color: #818cf8;
+}
+
+.blog-card__link,
+.blog-post__back {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  color: #cbd5f5;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.blog-post__header h1 {
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  margin: 0 0 1rem;
+}
+
+.blog-post__body {
+  display: grid;
+  gap: 1.5rem;
+  color: #e2e8f0;
+}
+
+.blog-post__body p {
+  margin: 0;
+}
+
+@media (max-width: 640px) {
+  .blog-page-wrapper {
+    padding: 0 1.25rem;
+  }
+
+  main.blog-container,
+  main.blog-post {
+    padding: 5rem 1rem 3rem;
+  }
+
+  .blog-card {
+    padding: 1.5rem;
+  }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,140 +1,331 @@
-import Script from "next/script";
+"use client";
+
+import Link from "next/link";
+import type { MouseEvent } from "react";
+import { useCallback, useEffect, useState } from "react";
+
+type NavSection = {
+  id: string;
+  label: string;
+};
+
+type Work = {
+  title: string;
+  description: string;
+  period: string;
+};
+
+type Skill = {
+  name: string;
+  level: number;
+};
+
+type LinkItem = {
+  label: string;
+  href: string;
+};
+
+const NAV_SECTIONS: NavSection[] = [
+  { id: "about", label: "About" },
+  { id: "works", label: "Works" },
+  { id: "skill", label: "Skill" }
+];
+
+const WORKS: Work[] = [
+  {
+    title: "Apple Japan",
+    description: "Sales Specialist - Fukuoka",
+    period: "2024/06/01 - 2024/11/30"
+  },
+  {
+    title: "LabBase",
+    description: "Corporate Engineer",
+    period: "2023/10/17 - 2024/01/31"
+  }
+];
+
+const SKILLS: Skill[] = [
+  { name: "Actix-Web", level: 85 },
+  { name: "Rust", level: 70 },
+  { name: "TypeScript", level: 60 }
+];
+
+const SOCIAL_LINKS: LinkItem[] = [
+  {
+    label: "LinkedIn",
+    href: "https://www.linkedin.com/in/sotaro-furukawa-7b6050304"
+  },
+  {
+    label: "Facebook",
+    href: "https://www.facebook.com/furukawa.sotaro.5"
+  }
+];
+
+const ACTIVITY_LINKS: LinkItem[] = [
+  {
+    label: "活動が紹介された記事タイトル",
+    href: "https://example.com/article"
+  },
+  {
+    label: "活動紹介のYouTube動画",
+    href: "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+  }
+];
 
 export default function HomePage() {
+  const [activeSection, setActiveSection] = useState<string>(NAV_SECTIONS[0]?.id ?? "");
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const observedSections = NAV_SECTIONS
+      .map((section) => document.getElementById(section.id))
+      .filter((section): section is HTMLElement => Boolean(section));
+
+    if (!("IntersectionObserver" in window) || observedSections.length === 0) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            const id = entry.target.getAttribute("id");
+            if (id) {
+              setActiveSection(id);
+            }
+          }
+        });
+      },
+      {
+        rootMargin: "-45% 0px -45% 0px",
+        threshold: 0.1
+      }
+    );
+
+    observedSections.forEach((section) => observer.observe(section));
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  const handleNavClick = useCallback(
+    (event: MouseEvent<HTMLAnchorElement>, id: string) => {
+      if (typeof window === "undefined") {
+        return;
+      }
+
+      const targetSection = document.getElementById(id);
+      if (!targetSection) {
+        return;
+      }
+
+      const prefersReducedMotion = window
+        .matchMedia("(prefers-reduced-motion: reduce)")
+        .matches;
+
+      if (prefersReducedMotion) {
+        return;
+      }
+
+      event.preventDefault();
+
+      const header = document.querySelector<HTMLElement>("[data-site-header]");
+      const headerOffset = header?.offsetHeight ?? 0;
+      const top =
+        targetSection.getBoundingClientRect().top + window.scrollY - headerOffset - 16;
+
+      window.scrollTo({
+        top,
+        behavior: "smooth"
+      });
+    },
+    []
+  );
+
+  const navItemClass = (isActive = false) =>
+    [
+      "relative rounded-full px-4 py-2 transition-colors text-inherit",
+      "after:absolute after:bottom-1 after:left-3 after:right-3 after:h-0.5 after:origin-left after:scale-x-0 after:bg-[#3f8efc] after:transition-transform after:content-['']",
+      "hover:text-slate-900 hover:after:scale-x-100",
+      "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#3f8efc]",
+      isActive ? "bg-[#e7efff] text-slate-900 after:scale-x-100" : ""
+    ].join(" ");
+
   return (
-    <>
-      <header className="site-header">
-        <div className="brand">
-          <span className="brand__name">sou31415</span>
-          <span className="brand__role">Portfolio</span>
+    <div className="flex min-h-screen flex-col items-center gap-10 bg-[#f4f6fb] px-4 py-8 sm:py-12">
+      <header
+        data-site-header
+        className="sticky top-4 z-10 w-full max-w-4xl rounded-[18px] border border-[#dfe3eb] bg-white/90 px-6 py-5 shadow-2xl shadow-slate-400/20 backdrop-blur-md transition-colors sm:px-8"
+      >
+        <div className="flex flex-col gap-6 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex flex-col gap-1 text-sm uppercase tracking-[0.08em] text-slate-500">
+            <span className="text-base font-semibold text-slate-900">sou31415</span>
+            <span>Portfolio</span>
+          </div>
+          <nav
+            aria-label="主要ナビゲーション"
+            className="flex flex-wrap gap-3 text-sm font-medium text-slate-500"
+          >
+            {NAV_SECTIONS.map(({ id, label }) => {
+              const isActive = activeSection === id;
+              return (
+                <a
+                  key={id}
+                  href={`#${id}`}
+                  aria-current={isActive ? "location" : undefined}
+                  onClick={(event) => handleNavClick(event, id)}
+                  className={navItemClass(isActive)}
+                >
+                  {label}
+                </a>
+              );
+            })}
+            <Link key="blog" href="/blog" className={navItemClass()}>
+              Blog
+            </Link>
+          </nav>
         </div>
-        <nav className="site-nav" aria-label="主要ナビゲーション">
-          <a href="#about">About</a>
-          <a href="#works">Works</a>
-          <a href="#skill">Skill</a>
-        </nav>
       </header>
 
-      <main className="site-main">
-        <section id="about" className="panel" aria-labelledby="about-title">
-          <div className="panel__inner">
-            <h2 id="about-title" className="panel__title">
+      <main className="w-full max-w-4xl space-y-8 sm:space-y-10">
+        <section
+          id="about"
+          className="rounded-[22px] border border-[#dfe3eb] bg-white/80 shadow-xl shadow-slate-200/60 backdrop-blur"
+          aria-labelledby="about-title"
+        >
+          <div className="grid gap-6 p-6 sm:gap-7 sm:p-10">
+            <h2
+              id="about-title"
+              className="relative inline-flex items-center gap-3 text-lg font-semibold tracking-[0.06em] text-slate-900 before:block before:h-0.5 before:w-8 before:rounded-full before:bg-[#3f8efc] before:content-['']"
+            >
               About
             </h2>
-            <p>Webバックエンドが好き。</p>
-            <ul className="info-grid" aria-label="プロフィール情報">
-              <li>
-                <span className="info-grid__label">Place</span>
-                <span className="info-grid__value">Tokyo, Fukuoka</span>
-              </li>
-              <li>
-                <span className="info-grid__label">Tech</span>
-                <span className="info-grid__value">Web-Back,Web-Front,UI/UX...</span>
-              </li>
-              <li>
-                <span className="info-grid__label" />
-                <span className="info-grid__value">Minimal, Calm, Glassmorphism</span>
-              </li>
+            <p className="text-base text-slate-600">Webバックエンドが好き。</p>
+            <ul className="grid gap-4 text-sm text-slate-600" aria-label="プロフィール情報">
+              {[
+                { label: "Place", value: "Tokyo, Fukuoka" },
+                { label: "Tech", value: "Web-Back,Web-Front,UI/UX..." },
+                { label: "", value: "Minimal, Calm, Glassmorphism" }
+              ].map(({ label, value }) => (
+                <li key={`${label}-${value}`} className="grid gap-1">
+                  {label ? (
+                    <span className="text-xs font-medium uppercase tracking-[0.12em] text-slate-500">
+                      {label}
+                    </span>
+                  ) : null}
+                  <span className="text-base font-medium text-slate-900">{value}</span>
+                </li>
+              ))}
             </ul>
-            <div className="about__social">
-              <span className="info-grid__label">SNS</span>
-              <div className="social-links" aria-label="SNSアカウント" data-social-list>
-                <a
-                  className="social-links__item"
-                  href="https://www.linkedin.com/in/sotaro-furukawa-7b6050304"
-                  aria-label="LinkedIn"
-                  data-platform="LinkedIn"
+            <div className="grid gap-4">
+              <div className="grid gap-2">
+                <span className="text-xs font-medium uppercase tracking-[0.12em] text-slate-500">
+                  SNS
+                </span>
+                <div
+                  aria-label="SNSアカウント"
+                  data-social-list
+                  className="flex flex-wrap gap-3"
                 >
-                  LinkedIn
-                </a>
-                <a
-                  className="social-links__item"
-                  href="https://www.facebook.com/furukawa.sotaro.5"
-                  aria-label="Facebook"
-                  data-platform="Facebook"
-                >
-                  Facebook
-                </a>
+                  {SOCIAL_LINKS.map(({ label, href }) => (
+                    <a
+                      key={href}
+                      className="inline-flex items-center justify-center rounded-full border border-transparent bg-[#f0f3f9] px-4 py-2 text-sm font-medium text-slate-500 transition-colors hover:border-[#3f8efc] hover:bg-[#e7efff] hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#3f8efc]"
+                      href={href}
+                    >
+                      {label}
+                    </a>
+                  ))}
+                </div>
+              </div>
+              <div className="grid gap-2">
+                <span className="text-xs font-medium uppercase tracking-[0.12em] text-slate-500">
+                  Activity
+                </span>
+                <ul className="grid gap-2 text-sm" aria-label="活動が紹介された記事や動画">
+                  {ACTIVITY_LINKS.map(({ label, href }) => (
+                    <li key={href}>
+                      <a
+                        href={href}
+                        className="inline-flex items-center gap-2 rounded-xl border border-transparent bg-[#f0f3f9] px-4 py-2 text-slate-500 transition-colors hover:border-[#3f8efc] hover:bg-[#e7efff] hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#3f8efc]"
+                      >
+                        {label}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
               </div>
             </div>
-            <div className="about__media">
-              <span className="info-grid__label">Activity</span>
-              <ul className="media-links" aria-label="活動が紹介された記事や動画">
-                <li>
-                  <a href="https://example.com/article" className="media-links__item">
-                    活動が紹介された記事タイトル
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href="https://www.youtube.com/watch?v=dQw4w9WgXcQ"
-                    className="media-links__item"
-                  >
-                    活動紹介のYouTube動画
-                  </a>
-                </li>
-              </ul>
-            </div>
           </div>
         </section>
 
-        <section id="works" className="panel" aria-labelledby="works-title">
-          <div className="panel__inner">
-            <h2 id="works-title" className="panel__title">
+        <section
+          id="works"
+          className="rounded-[22px] border border-[#dfe3eb] bg-white/80 shadow-xl shadow-slate-200/60 backdrop-blur"
+          aria-labelledby="works-title"
+        >
+          <div className="grid gap-6 p-6 sm:gap-7 sm:p-10">
+            <h2
+              id="works-title"
+              className="relative inline-flex items-center gap-3 text-lg font-semibold tracking-[0.06em] text-slate-900 before:block before:h-0.5 before:w-8 before:rounded-full before:bg-[#3f8efc] before:content-['']"
+            >
               Works
             </h2>
-            <div className="works">
-              <article className="card">
-                <h3 className="card__title">Apple Japan</h3>
-                <p className="card__desc">Sales Specialist - Fukuoka</p>
-                <span className="card__meta">2024/06/01 - 2024/11/30</span>
-              </article>
-              <article className="card">
-                <h3 className="card__title">LabBase</h3>
-                <p className="card__desc">Corporate Engineer</p>
-                <span className="card__meta">2023/10/17 - 2024/01/31</span>
-              </article>
+            <div className="grid gap-4 sm:grid-cols-2 sm:gap-5">
+              {WORKS.map((work) => (
+                <article
+                  key={work.title}
+                  className="grid gap-3 rounded-2xl border border-[#dfe3eb] bg-[#f0f3f9] p-5 transition-all hover:-translate-y-1 hover:border-[#3f8efc] hover:shadow-xl hover:shadow-[#3f8efc]/20 focus-within:-translate-y-1 focus-within:border-[#3f8efc] focus-within:shadow-xl focus-within:shadow-[#3f8efc]/20"
+                >
+                  <h3 className="text-lg font-semibold text-slate-900">{work.title}</h3>
+                  <p className="text-sm text-slate-500">{work.description}</p>
+                  <span className="text-xs font-medium uppercase tracking-[0.12em] text-slate-500">
+                    {work.period}
+                  </span>
+                </article>
+              ))}
             </div>
           </div>
         </section>
 
-        <section id="skill" className="panel" aria-labelledby="skill-title">
-          <div className="panel__inner">
-            <h2 id="skill-title" className="panel__title">
+        <section
+          id="skill"
+          className="rounded-[22px] border border-[#dfe3eb] bg-white/80 shadow-xl shadow-slate-200/60 backdrop-blur"
+          aria-labelledby="skill-title"
+        >
+          <div className="grid gap-6 p-6 sm:gap-7 sm:p-10">
+            <h2
+              id="skill-title"
+              className="relative inline-flex items-center gap-3 text-lg font-semibold tracking-[0.06em] text-slate-900 before:block before:h-0.5 before:w-8 before:rounded-full before:bg-[#3f8efc] before:content-['']"
+            >
               Skill
             </h2>
-            <ul className="skill-list">
-              <li>
-                <span>Actix-Web</span>
-                <span className="skill-list__bar" aria-hidden="true">
-                  <span style={{ width: "85%" }} />
-                </span>
-                <span className="sr-only">85%</span>
-              </li>
-              <li>
-                <span>Rust</span>
-                <span className="skill-list__bar" aria-hidden="true">
-                  <span style={{ width: "70%" }} />
-                </span>
-                <span className="sr-only">70%</span>
-              </li>
-              <li>
-                <span>TypeScript</span>
-                <span className="skill-list__bar" aria-hidden="true">
-                  <span style={{ width: "60%" }} />
-                </span>
-                <span className="sr-only">60%</span>
-              </li>
+            <ul className="grid gap-4" aria-label="スキルレベル">
+              {SKILLS.map((skill) => (
+                <li key={skill.name} className="grid gap-2">
+                  <span className="text-base font-medium text-slate-900">{skill.name}</span>
+                  <span className="sr-only">{skill.level}%</span>
+                  <div className="relative h-2 overflow-hidden rounded-full bg-[#f0f3f9]">
+                    <div
+                      className="h-full rounded-full bg-gradient-to-r from-[#3f8efc] to-[#6bb3ff]"
+                      style={{ width: `${skill.level}%` }}
+                      aria-hidden="true"
+                    />
+                  </div>
+                </li>
+              ))}
             </ul>
           </div>
         </section>
       </main>
 
-      <footer className="site-footer">
+      <footer className="w-full max-w-4xl pb-6 text-center text-sm text-slate-500">
         <small>2024 sou31415</small>
       </footer>
-
-      <Script src="/assets/js/portfolio.js" strategy="afterInteractive" />
-    </>
+    </div>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,9 +16,25 @@
         "@types/node": "20.14.10",
         "@types/react": "18.3.3",
         "@types/react-dom": "18.3.0",
+        "autoprefixer": "^10.4.21",
         "eslint": "8.57.0",
         "eslint-config-next": "14.2.5",
+        "postcss": "^8.5.6",
+        "tailwindcss": "^3.4.13",
         "typescript": "5.4.5"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@emnapi/core": {
@@ -201,6 +217,45 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -997,6 +1052,34 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -1201,6 +1284,44 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/autoprefixer": {
+      "version": "10.4.21",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
+      "integrity": "sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.24.4",
+        "caniuse-lite": "^1.0.30001702",
+        "fraction.js": "^4.3.7",
+        "normalize-range": "^0.1.2",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -1244,6 +1365,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.8.16",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.16.tgz",
+      "integrity": "sha512-OMu3BGQ4E7P1ErFsIPpbJh0qvDudM/UuJeHgkAvfWe+0HFJCXh+t/l8L6fVLR55RI/UbKrVLnAXZSVwd9ysWYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -1266,6 +1410,40 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.26.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.26.3.tgz",
+      "integrity": "sha512-lAUU+02RFBuCKQPj/P6NgjlbCnLBMp4UtgTx7vNHd3XSIJF87s9a5rA3aH2yw3GS9DqZAUbOtZdCCiZeVRqt0w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.8.9",
+        "caniuse-lite": "^1.0.30001746",
+        "electron-to-chromium": "^1.5.227",
+        "node-releases": "^2.0.21",
+        "update-browserslist-db": "^1.1.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
     "node_modules/busboy": {
@@ -1339,6 +1517,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001748",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001748.tgz",
@@ -1376,6 +1564,44 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -1402,6 +1628,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1422,6 +1658,19 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/csstype": {
@@ -1553,6 +1802,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -1565,6 +1821,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
@@ -1600,6 +1863,13 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.235",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.235.tgz",
+      "integrity": "sha512-i/7ntLFwOdoHY7sgjlTIDo4Sl8EdoTjWIaKinYOVfC6bOp71bmwenyZthWHcasxgHDNWbWxvG9M3Ia116zIaYQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -1783,6 +2053,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -2404,12 +2684,41 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/fraction.js": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
+      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -2893,6 +3202,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-boolean-object": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
@@ -3312,6 +3634,16 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3424,6 +3756,23 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/lilconfig": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
+      "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -3541,6 +3890,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -3632,6 +3993,61 @@
         }
       }
     },
+    "node_modules/next/node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.23",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.23.tgz",
+      "integrity": "sha512-cCmFDMSm26S6tQSDpBCg/NR8NENrVPhAJSf+XbxBG4rPFaaonlEoE9wHQmun+cls499TQGSb7ZyPBRlzgKfpeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -3640,6 +4056,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/object-inspect": {
@@ -3929,6 +4355,26 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -3940,9 +4386,10 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -3959,13 +4406,104 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -4051,6 +4589,29 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -4753,6 +5314,29 @@
         }
       }
     },
+    "node_modules/sucrase": {
+      "version": "3.35.0",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
+      "integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "glob": "^10.3.10",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -4779,12 +5363,122 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tailwindcss": {
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.13.tgz",
+      "integrity": "sha512-KqjHOJKogOUt5Bs752ykCeiwvi0fKVkr5oqsFNt/8px/tA8scFPIlkygsf6jXrfCqGHz7VflA6+yytWuM+XhFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.5.3",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.0",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.0",
+        "lilconfig": "^2.1.0",
+        "micromatch": "^4.0.5",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.0.0",
+        "postcss": "^8.4.23",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.1",
+        "postcss-nested": "^6.0.1",
+        "postcss-selector-parser": "^6.0.11",
+        "resolve": "^1.22.2",
+        "sucrase": "^3.32.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/postcss-load-config": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
+      "integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.0.0",
+        "yaml": "^2.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      },
+      "peerDependencies": {
+        "postcss": ">=8.0.9",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "postcss": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tailwindcss/node_modules/postcss-load-config/node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
@@ -4859,6 +5553,13 @@
       "peerDependencies": {
         "typescript": ">=4.2.0"
       }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
@@ -5058,6 +5759,37 @@
         "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
       }
     },
+    "node_modules/update-browserslist-db": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -5067,6 +5799,13 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -5290,6 +6029,19 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,11 @@
     "@types/node": "20.14.10",
     "@types/react": "18.3.3",
     "@types/react-dom": "18.3.0",
+    "autoprefixer": "^10.4.21",
     "eslint": "8.57.0",
     "eslint-config-next": "14.2.5",
+    "postcss": "^8.5.6",
+    "tailwindcss": "^3.4.13",
     "typescript": "5.4.5"
   }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,13 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    "./app/**/*.{js,ts,jsx,tsx,mdx}",
+    "./components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./pages/**/*.{js,ts,jsx,tsx,mdx}",
+    "./docs/**/*.{md,mdx}"
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- wrap blog routes with a dedicated layout that fills the desktop background and reuse a shared article renderer
- convert each blog article into its own static route file while keeping the existing metadata
- add a Blog entry to the homepage navigation to link out of the single-page sections

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ee7824ecc08326806b6a0f9a56527e